### PR TITLE
Feature/suspense errorboundary

### DIFF
--- a/src/shared/components/boundaries/AsyncSuspense.tsx
+++ b/src/shared/components/boundaries/AsyncSuspense.tsx
@@ -1,0 +1,19 @@
+import { ReactNode, Suspense } from 'react';
+import type { ReactElement } from 'react';
+import { useClientSide } from '../../hooks/useClientSide';
+
+interface Props {
+  suspense: ReactElement<{ fallback: ReactElement }>;
+  children: ReactNode;
+}
+
+export const AsyncSuspense = (props: Props) => {
+  const { suspense: suspenseFallback, children } = props;
+  const { isMounted } = useClientSide();
+  return (
+    <>
+      {isMounted && <Suspense {...suspenseFallback.props}>{children}</Suspense>}
+      {!isMounted && <>{suspenseFallback}</>}
+    </>
+  );
+};

--- a/src/shared/components/boundaries/CompositionBoundary.tsx
+++ b/src/shared/components/boundaries/CompositionBoundary.tsx
@@ -1,0 +1,43 @@
+import type { ReactElement, ReactNode } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
+import { ErrorBoundaryWithQuery } from './ErrorBoundaryWithQuery';
+import { AsyncSuspense } from './AsyncSuspense';
+import { CommonErrorFallback } from './CommonErrorFallback';
+import type { FallbackProps } from 'react-error-boundary';
+
+interface ExtendFallbackProps extends FallbackProps {
+  reset?: (...args: unknown[]) => void;
+  retry?: (...args: unknown[]) => void;
+}
+
+interface CompositionBoundaryProps {
+  children: ReactNode;
+  suspense: ReactElement<{ fallback: ReactElement }>;
+  queryBoundary?: boolean;
+  error: (props: ExtendFallbackProps) => ReactNode;
+  reset?: (...args: unknown[]) => void;
+  retry?: (...args: unknown[]) => void;
+}
+
+export const CompositionBoundary = (props: CompositionBoundaryProps) => {
+  const { children, reset, retry, suspense, error: errorFallback = CommonErrorFallback, queryBoundary = false } = props;
+  const { fallback: suspenseFallback } = suspense.props;
+
+  if (queryBoundary) {
+    return (
+      <ErrorBoundaryWithQuery fallback={errorFallback}>
+        <AsyncSuspense suspense={suspenseFallback} children={children} />
+      </ErrorBoundaryWithQuery>
+    );
+  }
+
+  return (
+    <ErrorBoundary
+      fallbackRender={({ error, resetErrorBoundary }: FallbackProps) => (
+        <>{errorFallback({ resetErrorBoundary, error, reset, retry })}</>
+      )}
+    >
+      <AsyncSuspense suspense={suspenseFallback} children={children} />
+    </ErrorBoundary>
+  );
+};

--- a/src/shared/components/boundaries/ErrorBoundaryWithQuery.tsx
+++ b/src/shared/components/boundaries/ErrorBoundaryWithQuery.tsx
@@ -1,0 +1,28 @@
+import type { ReactNode } from 'react';
+import { useQueryErrorResetBoundary } from 'react-query';
+import { ErrorBoundary, FallbackProps } from 'react-error-boundary';
+
+interface ExtendFallbackProps extends FallbackProps {
+  reset: (...args: unknown[]) => void;
+  retry?: (...args: unknown[]) => void;
+}
+
+interface Props {
+  children: ReactNode;
+  fallback: (props: ExtendFallbackProps) => ReactNode;
+  retry?: (...args: unknown[]) => void;
+}
+
+export const ErrorBoundaryWithQuery = (props: Props) => {
+  const { children, fallback, retry } = props;
+  const { reset } = useQueryErrorResetBoundary();
+  return (
+    <ErrorBoundary
+      fallbackRender={({ error, resetErrorBoundary }: FallbackProps) => (
+        <>{fallback({ resetErrorBoundary, error, reset, retry })}</>
+      )}
+    >
+      {children}
+    </ErrorBoundary>
+  );
+};

--- a/src/shared/hooks/useClientSide.ts
+++ b/src/shared/hooks/useClientSide.ts
@@ -1,0 +1,10 @@
+import { useEffect, useState } from 'react';
+
+export const useClientSide = () => {
+  const [isMounted, setIsMounted] = useState<boolean>(false);
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
+
+  return { isMounted };
+};


### PR DESCRIPTION
## Work Description ✅
공통으로 사용 할 Errorboundary & Suspense 합성 컴포넌트를 구현하였습니다.

### Interface
```typescript
interface CompositionBoundaryProps {
  children: ReactNode; //정상적으로 표시 할 컴포넌트 
  suspense: ReactElement<{ fallback: ReactElement }>; //Suspense fallback 컴포넌트
  error: (props: ExtendFallbackProps) => ReactNode; //ErrorBoundary fallback 컴포넌트
  queryBoundary?: boolean; //ReactQuery `reset` 여부 *사용 시 ErrorBoundary fallback에 reset에 위임 
  reset?: (...args: unknown[]) => void; //reset 함수 (queryBoundary=false 일 때 활성화 됩니다.)
  retry?: (...args: unknown[]) => void; //retry 함수
  resetBoundary:
}

```

### usage

```jsx
//📂auth/component/LoginErrorFallback.tsx
interface ErrorProps {
  error: Error | FirebaseError;
  resetErrorBoundary: (...args: unknown[]) => void;
  reset?: (...args: unknown[]) => void;
  retry?: (...args: unknown[]) => void;
}
export const LoginErrorFallback = (props: ErrorProps) => {
  const { error, resetErrorBoundary: resetBoundary, reset, retry } = props;

  const onReset = () => {
    resetBoundary();
    if (reset) {
      reset();
    }
    if (retry) {
      retry();
    }
  };

  return (
    <div>
      <h2>로그인과정에 오류가 발생하였습니다.</h2>
      <p>{error.message}</p>
      <button onClick={onReset} type="button">
        재시도
      </button>
    </div>
  );
};
```

```jsx
<CompositionBoundary queryBoundary error={LoginErrorFallback} suspense={<Suspense fallback={<Loading />} />}>
  <UserProfile />
</CompositionBoundary>;


<CompositionBoundary
  retry={() => { mutate() }}
  error={LoginErrorFallback}
  suspense={<Suspense fallback={<Loading />} />}
>
  <UserProfile />
</CompositionBoundary>;


```

## Questions and Concerns 💡
현재는 공용으로 사용할 fallback `CommonErrorFallback`을 프로토타입으로 구성해보았는데, 공용으로 사용할 수 있는 단순한 flat UI를 어떤 인터페이스 형태로 구성해야할 지 고민이 많습니다. `CompositionBoundary`에서 별도의 fallback을 넘기지 않을 때는 임시로 표시하도록 생각해봤는데, title까지 고려하면 외부에서 너무 많은 정보를 알아야 하는 것 같아서 분리 방법을 더 고민해봐야 할 것 같습니다.

## Screenshots 🖥️
