### PR TITLE
Feature/workspace list

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@emotion/react": "^11.10.8",
     "@emotion/styled": "^11.10.8",
-    "@jdesignlab/react": "^0.10.2",
+    "@jdesignlab/react": "^0.10.3",
     "@jdesignlab/react-icons": "^0.7.0",
     "@toast-ui/editor": "^3.2.2",
     "@toast-ui/editor-plugin-code-syntax-highlight": "^3.1.0",
@@ -38,6 +38,7 @@
     "react-dom": "^18.2.0",
     "react-error-boundary": "^4.0.9",
     "react-hook-form": "^7.43.9",
+    "react-intersection-observer": "^9.5.2",
     "react-query": "^3.39.3",
     "xstate": "^4.37.2"
   },

--- a/src/auth/hooks/useSetUserAuthData.ts
+++ b/src/auth/hooks/useSetUserAuthData.ts
@@ -1,10 +1,10 @@
-import { QUREY_KEYS } from '@shared/constants';
+import { QUERY_KEYS } from '@shared/constants';
 import { useQueryClient } from 'react-query';
 import { User } from 'firebase/auth';
 
 export const useSetUserAuthData = () => {
   const queryClient = useQueryClient();
-  const { user } = QUREY_KEYS;
+  const { user } = QUERY_KEYS;
 
   const updateUserData = (newData: User | null) => {
     queryClient.setQueryData(user, newData);

--- a/src/auth/hooks/useSignout.ts
+++ b/src/auth/hooks/useSignout.ts
@@ -1,5 +1,5 @@
 import { clearLocalStorageItem } from '@shared/storage';
-import { STORAGE_KEYS, QUREY_KEYS } from '@shared/constants';
+import { STORAGE_KEYS, QUERY_KEYS } from '@shared/constants';
 import { useMutation, useQueryClient } from 'react-query';
 import { signOut } from 'next-auth/react';
 import { fetchSignout } from '../remotes/fetchSignout';
@@ -7,7 +7,7 @@ import { fetchSignout } from '../remotes/fetchSignout';
 export const useSignout = () => {
   const queryClient = useQueryClient();
   const { userAuth } = STORAGE_KEYS;
-  const { user } = QUREY_KEYS;
+  const { user } = QUERY_KEYS;
   const { mutate, isLoading } = useMutation(fetchSignout, {
     onSuccess: () => {
       signOut();

--- a/src/auth/remotes/fetchUserAuth.ts
+++ b/src/auth/remotes/fetchUserAuth.ts
@@ -1,5 +1,5 @@
 import { auth } from '@shared/firebase';
-import { QUREY_KEYS } from '@shared/constants';
+import { QUERY_KEYS } from '@shared/constants';
 import { setLocalStorageItem, STORAGE_KEYS } from '@shared/storage';
 import { onAuthStateChanged } from 'firebase/auth';
 import { useQuery } from 'react-query';
@@ -18,7 +18,7 @@ export const fetchUserAuth = (): Promise<User | null> =>
   });
 
 export const useUserAuth = () => {
-  const { data } = useQuery<User | null>(QUREY_KEYS.user, fetchUserAuth, {
+  const { data } = useQuery<User | null>(QUERY_KEYS.user, fetchUserAuth, {
     initialData: null,
     onSuccess: (user) => {
       setLocalStorageItem(STORAGE_KEYS.userAuth, user);

--- a/src/pages/api/post/get.ts
+++ b/src/pages/api/post/get.ts
@@ -3,7 +3,7 @@ import { database } from '@shared/firebase';
 import { errorMessage } from '@shared/errorMessage';
 import { responseEntity } from '@shared/responseEntity';
 import { doc, getDoc } from 'firebase/firestore';
-import type { Post } from '@workspace/types';
+import type { QueryablePost } from '@workspace/types';
 import type { NextApiRequest, NextApiResponse } from 'next';
 
 type RequestParams = {
@@ -16,10 +16,10 @@ const getPostService = async (req: NextApiRequest, res: NextApiResponse) => {
     const { posts } = FIREBASE_COLLECTIONS;
 
     const postDocRef = doc(database, posts, postId);
-    const postData = (await getDoc(postDocRef)).data() as Post;
+    const postData = (await getDoc(postDocRef)).data() as QueryablePost;
 
     res.status(200).json(
-      responseEntity<Post>({
+      responseEntity<QueryablePost>({
         responseData: { ...postData, postId },
         success: true
       })

--- a/src/pages/api/workspace/get.ts
+++ b/src/pages/api/workspace/get.ts
@@ -1,0 +1,105 @@
+import { ApplicationError, FIREBASE_COLLECTIONS } from '@shared/constants';
+import { database } from '@shared/firebase';
+import { errorMessage } from '@shared/errorMessage';
+import { responseEntity } from '@shared/responseEntity';
+import {
+  collection,
+  getDocs,
+  getDoc,
+  query,
+  where,
+  getCountFromServer,
+  limit,
+  startAfter,
+  orderBy
+} from 'firebase/firestore';
+import type { UserProfile } from '@auth/types';
+import type { ChallengePostFields } from '@challenge/types';
+import type { DocumentReference } from 'firebase/firestore';
+import type { WorkspaceDocRef, Post, QueryableWorkspaceWithChallenge, WorkspaceWithChallenge } from '@workspace/types';
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+interface ChallengeRef extends Omit<ChallengePostFields, 'members'> {
+  userId: DocumentReference;
+  members: DocumentReference[];
+}
+
+type RequestParams = {
+  page: string;
+};
+
+const PAGE_VIEW = 10;
+const workspaceListService = async (req: NextApiRequest, res: NextApiResponse) => {
+  try {
+    if (req.method === 'GET') {
+      const { page } = req.query as RequestParams;
+      const currentPage = Number(page);
+      const { workspace, posts } = FIREBASE_COLLECTIONS;
+      const postsCollection = collection(database, posts);
+      const workspaceCollection = collection(database, workspace);
+      const totalCount = (await getCountFromServer(workspaceCollection)).data().count;
+
+      const workspaceQuery =
+        currentPage === 1
+          ? query(workspaceCollection, limit(PAGE_VIEW))
+          : query(workspaceCollection, orderBy('key'), startAfter(PAGE_VIEW * (currentPage - 1)), limit(PAGE_VIEW));
+      const workspaceListRef = await getDocs(workspaceQuery);
+
+      const workspaceListPromises = workspaceListRef.docs.map(async (workspaceDoc) => {
+        const workspaceId = workspaceDoc.id;
+        const workspaceData = workspaceDoc.data() as WorkspaceDocRef;
+        const { duration, content, memberCapacity, members, skill, userId, title } = (
+          await getDoc(workspaceData.challenge)
+        ).data() as ChallengeRef;
+
+        const parseMembers = members.length
+          ? await Promise.all(members.map(async (ref) => (await getDoc(ref)).data()))
+          : [];
+
+        const postQuery = query(
+          postsCollection,
+          where('originId', '==', workspaceId),
+          where('isDeleted', '==', false),
+          limit(5)
+        );
+        const postsByWorkspace = await getDocs(postQuery);
+        const postsPromise = postsByWorkspace.docs.map(async (post) => post.data());
+        const postsData = (await Promise.all(postsPromise)) as Post[];
+        const master = (await getDoc(userId)).data() as Omit<UserProfile, 'uid'>;
+        return {
+          challengeInfo: { duration, content, memberCapacity, members, skill, title },
+          posts: postsData,
+          master,
+          workspaceId,
+          members: parseMembers
+        };
+      });
+
+      const workspaceList = (await Promise.all(workspaceListPromises)) as unknown as WorkspaceWithChallenge[];
+
+      res.status(200).json(
+        responseEntity<QueryableWorkspaceWithChallenge>({
+          responseData: { workspaceList, totalCount, currentPage },
+          success: true
+        })
+      );
+      return;
+    }
+    res.status(405).json(
+      responseEntity<null>({
+        responseData: null,
+        success: false
+      })
+    );
+  } catch (error) {
+    res.status(500).json(
+      responseEntity<null>({
+        responseData: null,
+        success: false,
+        message: errorMessage(error ?? ApplicationError.SERVER)
+      })
+    );
+  }
+};
+
+export default workspaceListService;

--- a/src/pages/api/workspace/notice.ts
+++ b/src/pages/api/workspace/notice.ts
@@ -8,8 +8,8 @@ import { NextApiRequest, NextApiResponse } from 'next';
 const workspaceNoticeService = async (req: NextApiRequest, res: NextApiResponse) => {
   try {
     const ref = doc(database, FIREBASE_COLLECTIONS.workspace, 'JI7P1eXtAReQdlHcO9s4');
-    const worksapaceDoc = (await getDoc(ref)).data() as WorkspaceDocRef;
-    const { notice } = worksapaceDoc;
+    const workspaceDoc = (await getDoc(ref)).data() as WorkspaceDocRef;
+    const { notice } = workspaceDoc;
     if (typeof notice === 'string') {
       res.status(200).json(
         responseEntity<string>({

--- a/src/pages/api/workspace/post/create.ts
+++ b/src/pages/api/workspace/post/create.ts
@@ -20,6 +20,7 @@ const workspacePostService = async (req: NextApiRequest, res: NextApiResponse) =
     const insertedPost = await addDoc(collection(database, posts), {
       ...post,
       author: email ?? displayName,
+      originId: workspaceId,
       createdAt,
       authorId: uid,
       isDeleted: false

--- a/src/pages/api/workspace/post/get.ts
+++ b/src/pages/api/workspace/post/get.ts
@@ -3,7 +3,7 @@ import { database } from '@shared/firebase';
 import { responseEntity } from '@shared/responseEntity';
 import { errorMessage } from '@shared/errorMessage';
 import { doc, getDoc } from 'firebase/firestore';
-import type { WorkspaceDocRef, PeriodFormat, Post } from '@workspace/types';
+import type { WorkspaceDocRef, PeriodFormat, Post, QueryablePost } from '@workspace/types';
 import type { NextApiRequest, NextApiResponse } from 'next';
 
 type RequestParams = {
@@ -19,13 +19,13 @@ const workspacePostsService = async (req: NextApiRequest, res: NextApiResponse) 
     const workspaceTurn = (await getDoc(workspaceDocRef)).data() as WorkspaceDocRef;
 
     const posts = workspaceTurn[period].length
-      ? ((await Promise.all(
+      ? await Promise.all(
           workspaceTurn[period].map(async (ref) => {
-            const postData = (await getDoc(ref.post)).data() as Post;
+            const postData = (await getDoc(ref.post)).data() as QueryablePost;
             postData.postId = ref.post.id; // post 항목의 ID를 추가합니다.
             return postData;
           })
-        )) as Post[])
+        )
       : [];
 
     res.status(200).json(

--- a/src/pages/workspace/[workspaceId].tsx
+++ b/src/pages/workspace/[workspaceId].tsx
@@ -3,7 +3,7 @@ import { workspaceMachineContext } from '@workspace/machines/workspaceMachineCon
 import { WorkspaceSidebar } from '@workspace/components/aside/WorkspaceSidebar';
 import { WorkspaceMain } from '@workspace/components/main/WorkspaceMain';
 import { workspaceLayout } from '@workspace/styles/layout';
-import { workspaceContext } from '@workspace/workspaceContext';
+import { WorkspaceGroupContext } from '@workspace/contexts/workspaceGroupContext';
 import { GetServerSideProps } from 'next';
 import { getSession } from 'next-auth/react';
 import type { ContextProps } from '@workspace/types';
@@ -13,12 +13,12 @@ const WorkspacePage = (props: ContextProps) => {
   const memoizedWorkspaceId = useMemo(() => ({ workspaceId, userSession }), [workspaceId, userSession]);
   return (
     <workspaceMachineContext.Provider>
-      <workspaceContext.Provider value={memoizedWorkspaceId}>
+      <WorkspaceGroupContext.Provider value={memoizedWorkspaceId}>
         <section css={workspaceLayout}>
           <WorkspaceSidebar />
           <WorkspaceMain />
         </section>
-      </workspaceContext.Provider>
+      </WorkspaceGroupContext.Provider>
     </workspaceMachineContext.Provider>
   );
 };

--- a/src/pages/workspace/index.tsx
+++ b/src/pages/workspace/index.tsx
@@ -1,2 +1,25 @@
-const WorkspacePage = () => <div>workspace</div>;
+import { WorkspaceList } from '@workspace/components/WorkspaceList';
+import { QUERY_KEYS } from '@shared/constants';
+import { CompositionBoundaryReactQuery } from '@shared/boundaries';
+import { WorkspaceError } from '@workspace/components/WorkspaceError';
+import { Loader } from '@shared/components/suspense/Loader';
+import { QueryClient, dehydrate } from 'react-query';
+import { GetServerSideProps } from 'next';
+
+const WorkspacePage = () => (
+  <section>
+    workspace-filter
+    <CompositionBoundaryReactQuery error={(errorProps) => <WorkspaceError {...errorProps} />} suspense={<Loader />}>
+      <WorkspaceList />
+    </CompositionBoundaryReactQuery>
+  </section>
+);
 export default WorkspacePage;
+
+export const getServerSideProps: GetServerSideProps = async () => {
+  const { workspaceList } = QUERY_KEYS;
+  const queryClient = new QueryClient();
+  await queryClient.prefetchInfiniteQuery(workspaceList);
+
+  return { props: { dehydratedState: dehydrate(queryClient) } };
+};

--- a/src/shared/constants/firebaseCollections.ts
+++ b/src/shared/constants/firebaseCollections.ts
@@ -1,10 +1,10 @@
-type Collections = 'challenge' | 'comment' | 'dletedChallenge' | 'emoji' | 'user' | 'workspace' | 'posts';
+type Collections = 'challenge' | 'comment' | 'deletedChallenge' | 'emoji' | 'user' | 'workspace' | 'posts';
 
 export const FIREBASE_COLLECTIONS: Record<Collections, string> = {
   user: 'user',
   workspace: 'workspace',
-  dletedChallenge: 'deleted-challenge',
-  challenge: 'chellange',
+  deletedChallenge: 'deleted-challenge',
+  challenge: 'challenge',
   comment: 'comment',
   emoji: 'emoji',
   posts: 'posts'

--- a/src/shared/constants/reactQueryKeys.ts
+++ b/src/shared/constants/reactQueryKeys.ts
@@ -1,9 +1,10 @@
-type QueryKeys = 'user' | 'worksapace' | 'workspaceNotice' | 'workspacePosts' | 'post';
+type QueryKeys = 'user' | 'workspace' | 'workspaceNotice' | 'workspacePosts' | 'post' | 'workspaceList';
 
-export const QUREY_KEYS: Record<QueryKeys, string> = {
+export const QUERY_KEYS: Record<QueryKeys, string> = {
   user: 'user',
-  worksapace: 'worksapace',
+  workspace: 'workspace',
   workspaceNotice: 'workspace-notice',
   workspacePosts: 'workspace-posts',
+  workspaceList: 'workspace-list',
   post: 'post'
 };

--- a/src/workspace/components/WorkspaceError.tsx
+++ b/src/workspace/components/WorkspaceError.tsx
@@ -1,0 +1,23 @@
+import { Button, Text, Stack } from '@jdesignlab/react';
+import type { FallbackProps } from 'react-error-boundary';
+
+export const WorkspaceError = (errorProps: FallbackProps) => {
+  const { resetErrorBoundary } = errorProps;
+
+  return (
+    <div
+      css={{
+        display: 'inline-block'
+      }}
+    >
+      <Stack justify="center" align="center">
+        <Text size="lg" variant="heading">
+          리스트를 가져오는 중에 문제가 발생했습니다.
+        </Text>
+        <Button onClick={resetErrorBoundary} type="button">
+          재시도
+        </Button>
+      </Stack>
+    </div>
+  );
+};

--- a/src/workspace/components/WorkspaceItem.tsx
+++ b/src/workspace/components/WorkspaceItem.tsx
@@ -1,0 +1,72 @@
+import { Avatar } from '@shared/components/dataDisplay/Avatar';
+import { SKILLS } from '@shared/constants';
+import { useRouter } from 'next/router';
+import { Card, Text, Stack } from '@jdesignlab/react';
+import { File } from '@jdesignlab/react-icons';
+import { workspaceCardStyle, workspacePostSummaryStyle, workspacePostEmptyStyle } from '../styles/workspaceListStyle';
+import type { WorkspaceWithChallenge, Post } from '../types';
+
+interface Props {
+  workspaceItem: WorkspaceWithChallenge;
+}
+
+const PostSummary = ({ title }: Post) => (
+  <ol css={workspacePostSummaryStyle}>
+    <li>
+      <Stack>
+        <File width={18} height={18} fill="#f8a5c2" />
+        <Text variant="label">{title}</Text>
+      </Stack>
+    </li>
+  </ol>
+);
+
+const EmptyPost = () => (
+  <div css={workspacePostEmptyStyle}>
+    <Text variant="label">&#128576; 작성된 글이 없어요.</Text>
+  </div>
+);
+
+export const WorkspaceItem = ({ workspaceItem }: Props) => {
+  const { workspaceId, master, posts, challengeInfo, members } = workspaceItem;
+  const router = useRouter();
+  const memberProfile: string[] = members.map((member) => member.photo ?? '');
+  const workspaceMasterInfo = master.name ?? master.email;
+
+  const moveToWorkspace = (path: string) => {
+    router.push(path);
+  };
+
+  return (
+    <li key={workspaceId}>
+      <Card
+        css={workspaceCardStyle}
+        onClick={() => {
+          moveToWorkspace(`/workspace/${workspaceId}`);
+        }}
+      >
+        <Card.Header>
+          <Text variant="heading" size="lg" color="pink-lighten1">
+            {`${workspaceMasterInfo}의 Workpsace`}
+          </Text>
+        </Card.Header>
+        <Card.Divider />
+        <Card.Body css={{ width: '100%', marginTop: '8px' }}>
+          <Text variant="label" truncate>
+            작성 포스트
+          </Text>
+          {posts.length ? posts.map((post) => <PostSummary {...post} />) : <EmptyPost />}
+        </Card.Body>
+        <Card.Divider />
+        <Card.Footer css={{ width: '100%', height: '100%', padding: '0' }}>
+          <Text variant="heading" as="span">{`${members.length}명이서 `}</Text>
+          <Text as="span" color="pink-lighten3">
+            {SKILLS[challengeInfo.skill]}
+          </Text>
+          <Text as="span"> 기술을 공부하고 있어요</Text>
+          <Avatar.Group src={[...memberProfile]} />
+        </Card.Footer>
+      </Card>
+    </li>
+  );
+};

--- a/src/workspace/components/WorkspaceList.tsx
+++ b/src/workspace/components/WorkspaceList.tsx
@@ -1,0 +1,31 @@
+import { useEffect } from 'react';
+import { Loader } from '@shared/components/suspense/Loader';
+import { useInView } from 'react-intersection-observer';
+import { WorkspaceItem } from './WorkspaceItem';
+import { useQueryWorkspaceList } from '../hooks/useQueryWorkspaceList';
+import { workspaceListStyle } from '../styles/workspaceListStyle';
+import type { QueryableWorkspaceWithChallenge } from '../types';
+
+export const WorkspaceList = () => {
+  const [ref, inView] = useInView();
+  const { data, fetchNextPage, hasNextPage } = useQueryWorkspaceList();
+
+  useEffect(() => {
+    if (inView) {
+      fetchNextPage();
+    }
+  }, [fetchNextPage, inView]);
+
+  return (
+    <ol css={workspaceListStyle}>
+      {data?.pages.map((page: QueryableWorkspaceWithChallenge) =>
+        page.workspaceList.map((workspace) => <WorkspaceItem workspaceItem={workspace} />)
+      )}
+      {hasNextPage && (
+        <div ref={ref}>
+          <Loader />
+        </div>
+      )}
+    </ol>
+  );
+};

--- a/src/workspace/components/aside/GroupMemebers.tsx
+++ b/src/workspace/components/aside/GroupMemebers.tsx
@@ -3,10 +3,10 @@ import Image from 'next/image';
 import { Text } from '@jdesignlab/react';
 import { memberListStyle, memeberCardStyle, profileStyle } from '../../styles/sidebarStyle';
 import { useQueryWorkspace } from '../../hooks/useQueryWorkspace';
-import { workspaceContext } from '../../workspaceContext';
+import { WorkspaceGroupContext } from '../../contexts/workspaceGroupContext';
 
 export const GroupMemebers = () => {
-  const { workspaceId } = useContext(workspaceContext);
+  const { workspaceId } = useContext(WorkspaceGroupContext);
   const { data } = useQueryWorkspace(workspaceId);
 
   return (

--- a/src/workspace/components/main/TabList.tsx
+++ b/src/workspace/components/main/TabList.tsx
@@ -5,7 +5,7 @@ import { MarkdownEditor } from '@shared/components/markdownEditor';
 import { Tabs } from '@jdesignlab/react';
 import { EmptyPost } from './EmptyPost';
 import { workspaceMachineContext } from '../../machines/workspaceMachineContext';
-import { workspaceContext } from '../../workspaceContext';
+import { WorkspaceGroupContext } from '../../contexts/workspaceGroupContext';
 import { useQueryPosts } from '../../hooks/useQueryPosts';
 import { ContentExistTabItem } from '../posts/ContentExistTabItem';
 import { ContentNotExistTabItem } from '../posts/ContentNotExistTabItem';
@@ -13,7 +13,7 @@ import type { Post } from '../../types';
 
 export const TabList = () => {
   const [state] = workspaceMachineContext.useActor();
-  const { workspaceId, userSession } = useContext(workspaceContext);
+  const { workspaceId, userSession } = useContext(WorkspaceGroupContext);
   const { data: workspaceData } = useQueryWorkspace(workspaceId);
   const { data: notice } = useQueryWorkspaceNotice(workspaceId);
   const { data: posts } = useQueryPosts(state.context.period, workspaceId);

--- a/src/workspace/contexts/workspaceGroupContext.ts
+++ b/src/workspace/contexts/workspaceGroupContext.ts
@@ -1,0 +1,7 @@
+import { createContext } from 'react';
+import type { ContextProps } from '../types';
+
+export const WorkspaceGroupContext = createContext<ContextProps>({
+  workspaceId: '',
+  userSession: null
+});

--- a/src/workspace/hooks/useQueryPost.ts
+++ b/src/workspace/hooks/useQueryPost.ts
@@ -1,9 +1,9 @@
-import { QUREY_KEYS } from '@shared/constants';
+import { QUERY_KEYS } from '@shared/constants';
 import { useQuery } from 'react-query';
 import { fetchGetPost } from '../remotes/fetchGetPost';
 
 export const useQueryPost = (postId: string) => {
-  const { post } = QUREY_KEYS;
+  const { post } = QUERY_KEYS;
   const { data } = useQuery([post, postId], () => fetchGetPost(postId), {
     staleTime: 10000,
     cacheTime: 20000

--- a/src/workspace/hooks/useQueryPosts.ts
+++ b/src/workspace/hooks/useQueryPosts.ts
@@ -1,9 +1,9 @@
-import { QUREY_KEYS } from '@shared/constants';
+import { QUERY_KEYS } from '@shared/constants';
 import { useQuery } from 'react-query';
 import { fetchPosts } from '../remotes/fetchPosts';
 
 export const useQueryPosts = (period: string, workspaceId: string) => {
-  const { workspacePosts } = QUREY_KEYS;
+  const { workspacePosts } = QUERY_KEYS;
   const { data, refetch } = useQuery([workspacePosts, period], () => fetchPosts(period, workspaceId), {
     staleTime: 0,
     cacheTime: 0

--- a/src/workspace/hooks/useQueryWorkspace.ts
+++ b/src/workspace/hooks/useQueryWorkspace.ts
@@ -1,10 +1,10 @@
-import { QUREY_KEYS } from '@shared/constants/reactQueryKeys';
+import { QUERY_KEYS } from '@shared/constants/reactQueryKeys';
 import { fetchWorkspaceInfo } from '@workspace/remotes/fetchWorkspace';
 import { useQuery } from 'react-query';
 
 export const useQueryWorkspace = (workspaceId: string) => {
-  const { worksapace } = QUREY_KEYS;
-  const { data, refetch } = useQuery(worksapace, () => fetchWorkspaceInfo(workspaceId), {
+  const { workspace } = QUERY_KEYS;
+  const { data, refetch } = useQuery(workspace, () => fetchWorkspaceInfo(workspaceId), {
     staleTime: 10000,
     cacheTime: 20000
   });

--- a/src/workspace/hooks/useQueryWorkspaceList.ts
+++ b/src/workspace/hooks/useQueryWorkspaceList.ts
@@ -1,0 +1,24 @@
+import { QUERY_KEYS } from '@shared/constants/reactQueryKeys';
+import { useInfiniteQuery } from 'react-query';
+import { fetchWorkspaceList } from '../remotes/fetchWorkspaceList';
+
+export const useQueryWorkspaceList = () => {
+  const { workspaceList } = QUERY_KEYS;
+  const { data, fetchNextPage, hasNextPage } = useInfiniteQuery(
+    workspaceList,
+    ({ pageParam = 1 }) => fetchWorkspaceList(pageParam),
+    {
+      getNextPageParam: (lastPage) => {
+        const pageView = 10;
+        const nextPage = lastPage.currentPage + 1;
+        const nextItemCount = nextPage * pageView;
+        return lastPage.totalCount > nextItemCount ? nextPage : undefined;
+      },
+      refetchOnWindowFocus: false,
+      staleTime: 20000,
+      cacheTime: 10000
+    }
+  );
+
+  return { data, fetchNextPage, hasNextPage };
+};

--- a/src/workspace/hooks/useQueryWorkspaceNotice.ts
+++ b/src/workspace/hooks/useQueryWorkspaceNotice.ts
@@ -1,9 +1,9 @@
-import { QUREY_KEYS } from '@shared/constants/reactQueryKeys';
+import { QUERY_KEYS } from '@shared/constants/reactQueryKeys';
 import { fetchWorkspaceInfo } from '@workspace/remotes/fetchWorkspaceNotice';
 import { useQuery } from 'react-query';
 
 export const useQueryWorkspaceNotice = (workspaceId: string) => {
-  const { workspaceNotice } = QUREY_KEYS;
+  const { workspaceNotice } = QUERY_KEYS;
   const { data } = useQuery(workspaceNotice, () => fetchWorkspaceInfo(workspaceId));
 
   return { data };

--- a/src/workspace/remotes/fetchPosts.ts
+++ b/src/workspace/remotes/fetchPosts.ts
@@ -1,11 +1,11 @@
 import instance from '@shared/axiosInstance';
 import { errorMessage } from '@shared/errorMessage';
-import { Post } from '../types';
+import { QueryablePost } from '../types';
 import type { Response } from '@shared/responseEntity';
 
-export const fetchPosts = async (period: string, workspaceId: string): Promise<Post[]> => {
+export const fetchPosts = async (period: string, workspaceId: string): Promise<QueryablePost[]> => {
   try {
-    const { data } = await instance<Response<Post[]>>({
+    const { data } = await instance<Response<QueryablePost[]>>({
       method: 'get',
       url: '/workspace/post/get',
       params: { period, workspaceId }

--- a/src/workspace/remotes/fetchWorkspaceList.ts
+++ b/src/workspace/remotes/fetchWorkspaceList.ts
@@ -1,0 +1,20 @@
+import instance from '@shared/axiosInstance';
+import { errorMessage } from '@shared/errorMessage';
+import { QueryableWorkspaceWithChallenge } from '../types';
+import type { Response } from '@shared/responseEntity';
+
+export const fetchWorkspaceList = async (page: number): Promise<QueryableWorkspaceWithChallenge> => {
+  try {
+    const { data } = await instance<Response<QueryableWorkspaceWithChallenge>>({
+      method: 'GET',
+      url: '/workspace/get',
+      params: {
+        page: String(page)
+      }
+    });
+
+    return data.responseData;
+  } catch (error) {
+    throw new Error(errorMessage(error));
+  }
+};

--- a/src/workspace/styles/workspaceListStyle.ts
+++ b/src/workspace/styles/workspaceListStyle.ts
@@ -1,0 +1,53 @@
+import { mq } from '@shared/styles/mixins/responsive';
+import { css } from '@emotion/react';
+
+export const workspaceListStyle = css({
+  listStyle: 'none',
+  padding: '0',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  flexDirection: 'column',
+  gap: '32px',
+  [mq.md]: {
+    display: 'grid',
+    gridTemplateColumns: 'repeat(auto-fit, minmax(320px, 1fr))',
+    justifyItems: 'center'
+  }
+});
+
+export const workspaceCardStyle = css({
+  cursor: 'pointer',
+  minHeight: '240px',
+  minWidth: '320px',
+  '&:hover': {
+    boxShadow:
+      'rgba(0, 0, 0, 0.2) 0px 5px 6px -3px, rgba(0, 0, 0, 0.14) 0px 9px 12px 1px, rgba(0, 0, 0, 0.12) 0px 3px 16px 2px'
+  },
+  [mq.lg]: {
+    minHeight: '320px'
+  }
+});
+
+export const workspacePostSummaryStyle = css({
+  marginTop: '8px',
+  height: '120px',
+  width: 'auto',
+  borderRadius: '12px',
+  backgroundColor: '#f5f6fa',
+  listStyle: 'none',
+  padding: '8px'
+});
+
+export const workspacePostEmptyStyle = css({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  marginTop: '8px',
+  height: '120px',
+  width: 'auto',
+  borderRadius: '12px',
+  backgroundColor: '#f5f6fa',
+  listStyle: 'none',
+  padding: '8px'
+});

--- a/src/workspace/types.ts
+++ b/src/workspace/types.ts
@@ -1,7 +1,7 @@
 import { Session } from 'next-auth';
 import type { DocumentReference } from 'firebase/firestore';
 import type { UserProfile } from '@auth/types';
-import type { ChallengeHookFormValues } from '@challenge/types';
+import type { ChallengeHookFormValues, ChallengePostFields } from '@challenge/types';
 
 /** firebase Ref Type */
 export type PeriodFormat = `turn${number}`;
@@ -26,7 +26,6 @@ export interface ChallengeDocRef extends ChallengeHookFormValues {
 }
 
 /** data model */
-
 export interface ContextProps {
   workspaceId: string;
   userSession: Session | null;
@@ -37,6 +36,20 @@ export interface Workspace {
   challengeInfo: ChallengeDocRef;
 }
 
+export interface WorkspaceWithChallenge {
+  workspaceId: string;
+  posts: Post[];
+  master: Omit<UserProfile, 'uid'>;
+  members: UserProfile[];
+  challengeInfo: Pick<ChallengePostFields, 'duration' | 'content' | 'memberCapacity' | 'skill' | 'title'>;
+}
+
+export interface QueryableWorkspaceWithChallenge {
+  workspaceList: WorkspaceWithChallenge[];
+  totalCount: number;
+  currentPage: number;
+}
+
 export interface PostForm {
   postId: string;
   author: string;
@@ -45,11 +58,17 @@ export interface PostForm {
   workspaceId: string;
   turn: PeriodFormat;
 }
+
 export interface Post {
-  postId: string;
+  content: string;
+  originId: string;
+  title: string;
   authorId: string;
   author: string;
-  content: string;
   isDeleted: boolean;
-  title: string;
+  createdAt: string;
+}
+
+export interface QueryablePost extends Post {
+  postId: string;
 }

--- a/src/workspace/workspaceContext.ts
+++ b/src/workspace/workspaceContext.ts
@@ -1,7 +1,0 @@
-import { createContext } from 'react';
-import type { ContextProps } from './types';
-
-export const workspaceContext = createContext<ContextProps>({
-  workspaceId: '',
-  userSession: null
-});


### PR DESCRIPTION
## Work Description ✅

- Workspace 메인 페이지 레이아웃 구현 및 페이지네이션을 적용하였습니다.
- ReactQuery에서 제공하는 `useInfiniteQuery`와 `react-intersection-observer` 패키지를 활용하여 구성하였습니다.
## Questions and Concerns 💡
**1 ) 페이지네이션이 필요한 리스트들은 `useInfiniteQuery`를 사용하여 작성합니다.**
* `getNextPageParam`에서 다음 페이지네이션을 적용할지 판단을 내릴 수 있습니다.  (firebase api 호출 시 totalLength도 같이 구해주셔야 합니다.)
```jsx
export const useQueryWorkspaceList = () => {
  const { workspaceList } = QUERY_KEYS;
  const { data, fetchNextPage, hasNextPage } = useInfiniteQuery(
    workspaceList,
    ({ pageParam = 1 }) => fetchWorkspaceList(pageParam),
    {
      getNextPageParam: (lastPage) => {
        const pageView = 10;
        const nextPage = lastPage.currentPage + 1;
        const nextItemCount = nextPage * pageView;
        return lastPage.totalCount > nextItemCount ? nextPage : undefined;
      },
      refetchOnWindowFocus: false,
      staleTime: 20000,
      cacheTime: 10000
    }
  );

  return { data, fetchNextPage, hasNextPage };
};
```

**2 ) Firebase API 작성시 페이지네이션 계산**
1. 해당 리스트의 전체 갯수를 파악해 클라이언트로 내려줍니다. (useInfiniteQuery에서 사용하기 위함)
```jsx
import { getCountFromServer, ... } from 'firebase/firestore';
const totalCount = (await getCountFromServer(workspaceCollection)).data().count;
...
      res.status(200).json(
        responseEntity<QueryableWorkspaceWithChallenge>({
          responseData: { workspaceList, totalCount, currentPage },
          success: true
        })
      );
```   
2. 클라이언트에서 API 요청 시 요청 페이지를 URL 쿼리로 전달합니다.
    (`fetchNextPage()` 호출 시 알아서 다음 페이지 값이 계산되기 때문에 초기 페이지 요청 값만 잘 넘기시면 됩니다~!)
```jsx
const { data, fetchNextPage, hasNextPage } = useInfiniteQuery(
  workspaceList,
  ({ pageParam = 1 }) => fetchWorkspaceList(pageParam),
  { .... }
);
```
3. (2)에서 전달 받은 페이지를 `startAfter` 메서드를 통해 `Firestore` 구간 값을 추출할 수 있습니다.   
(저는 초기 값이 1일때는 첫 페이지 요청이기 때문에 0~limit 값까지만 가져오게끔 하고, 다음 요청부터는 `startAfter`를 통해 요청된 page ~ limit` 값을 가져올 수 있도록 하였습니다.
```
//pages/api/workspace/api/get.ts
const workspaceQuery =
  currentPage === 1
    ? query(workspaceCollection, limit(PAGE_VIEW))
    : query(workspaceCollection, orderBy('key'), startAfter(PAGE_VIEW * (currentPage - 1)), limit(PAGE_VIEW));
const workspaceListRef = await getDocs(workspaceQuery);

```

**3 ) 컴포넌트에서 해야할 것들**
컴포넌트에서는 `react-intersection-observer`에서 제공하는 `useInview`를 사용하여 감지할 요소의 ref를 설정하고, inView가 `true`가되면 `fetchNextPAge()`를 호출하는 형태로 구현하였습니다.

**useInfinityQuery에서 제공하는 것**
- fetchNextPage: 다음 페이징 값을 요청합니다. (getNextPageParam에 작성한 계산 로직에 따라서 알아서 판별)
- hasNextPage: 해당 페이지 요청이 마지막인지 확인합니다.

```jsx
import { useEffect } from 'react';
import { Loader } from '@shared/components/suspense/Loader';
import { useInView } from 'react-intersection-observer';
import { WorkspaceItem } from './WorkspaceItem';
import { useQueryWorkspaceList } from '../hooks/useQueryWorkspaceList';
import { workspaceListStyle } from '../styles/workspaceListStyle';
import type { QueryableWorkspaceWithChallenge } from '../types';

export const WorkspaceList = () => {
  const [ref, inView] = useInView();
  const { data, fetchNextPage, hasNextPage } = useQueryWorkspaceList();

  useEffect(() => {
    if (inView) {
      fetchNextPage();
    }
  }, [fetchNextPage, inView]);

  return (
    <ol css={workspaceListStyle}>
      {data?.pages.map((page: QueryableWorkspaceWithChallenge) =>
        page.workspaceList.map((workspace) => <WorkspaceItem workspaceItem={workspace} />)
      )}
      {hasNextPage && (
        <div ref={ref}>
          <Loader />
        </div>
      )}
    </ol>
  );
};

```


## Screenshots 🖥️
![workspace-list](https://github.com/DesignSystemLab/challenge-flow/assets/46988995/5aa5fc15-36c5-462f-8227-1eb3e86fab53)
